### PR TITLE
support better testability of StatusResponse

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -13,8 +13,22 @@ import (
 type (
 	Member             regattapb.Member
 	MemberListResponse regattapb.MemberListResponse
-	StatusResponse     regattapb.StatusResponse
+	TableStatus        regattapb.TableStatus
 )
+
+// StatusResponse represents response from Status API.
+type StatusResponse struct {
+	// id is the member ID of this member.
+	Id string
+	// version is the semver version used by the responding member.
+	Version string
+	// info is the additional server info.
+	Info string
+	// tables is a status of tables of the responding member.
+	Tables map[string]*TableStatus
+	// errors contains alarm/health information and status.
+	Errors []string
+}
 
 type Cluster interface {
 	// MemberList lists the current cluster membership.
@@ -74,7 +88,23 @@ func (c *cluster) Status(ctx context.Context, endpoint string) (*StatusResponse,
 	if err != nil {
 		return nil, toErr(ctx, err)
 	}
-	return (*StatusResponse)(resp), nil
+	return mapProtoStatusResponse(resp), nil
+}
+
+func mapProtoStatusResponse(resp *regattapb.StatusResponse) *StatusResponse {
+	tables := make(map[string]*TableStatus, len(resp.Tables))
+
+	for k, v := range resp.Tables {
+		tables[k] = (*TableStatus)(v)
+	}
+
+	return &StatusResponse{
+		Id:      resp.Id,
+		Version: resp.Version,
+		Info:    resp.Info,
+		Tables:  tables,
+		Errors:  resp.Errors,
+	}
 }
 
 type retryClusterClient struct {

--- a/cluster.go
+++ b/cluster.go
@@ -18,15 +18,15 @@ type (
 
 // StatusResponse represents response from Status API.
 type StatusResponse struct {
-	// id is the member ID of this member.
+	// Id is the member ID of this member.
 	Id string
-	// version is the semver version used by the responding member.
+	// Version is the semver version used by the responding member.
 	Version string
-	// info is the additional server info.
+	// Info is the additional server info.
 	Info string
-	// tables is a status of tables of the responding member.
+	// Tables is a status of tables of the responding member.
 	Tables map[string]*TableStatus
-	// errors contains alarm/health information and status.
+	// Errors contains alarm/health information and status.
 	Errors []string
 }
 


### PR DESCRIPTION
I am implementing support for listing tables into `regatta-client` and I bumped into issue when writing tests for StatusResponse. The problem is that [Tables](https://github.com/jamf/regatta-go/blob/main/internal/proto/regatta.pb.go#L1090) field is of type `map[string]*regattapb.TableStatus` and `regattapb` package is an internal package, therefore `Tables` field cannot be used in other projects trying to mock the `client.StatusResponse`

see my use-case: https://github.com/Tantalor93/regatta-client/pull/55/files#diff-34c013718c6a2afb65f0e305101a709c9b201a030c2cd650c8f62efe314def16R24